### PR TITLE
Send sync info at interval

### DIFF
--- a/config/defaults.ts
+++ b/config/defaults.ts
@@ -24,6 +24,7 @@ const defaultBaseConfig: PartialOgreConfig = {
     maxConnections: 30,
     gossipIntervalSec: 120,
     evictIntervalSec: 3600, // once an hour
+    syncIntervalSec: 5,
   },
   logging: {
     console: {

--- a/config/schema.ts
+++ b/config/schema.ts
@@ -65,6 +65,8 @@ export const ogreConfigSchema = z.object({
     maxConnections: z.number(),
     gossipIntervalSec: z.number(),
     evictIntervalSec: z.number(),
+    /** How often to send `SyncInfo` messages when node has not fully synced before */
+    syncIntervalSec: z.number(),
   }),
   logging: loggingConfigSchema,
 });

--- a/core/identifiable.ts
+++ b/core/identifiable.ts
@@ -1,6 +1,14 @@
+export type Guid = string & { readonly __brand: unique symbol };
+
+export const guid = {
+  new(): Guid {
+    return crypto.randomUUID() as Guid;
+  },
+};
+
 /** Implementors are uniquely identifiable based on a `guid` */
 export interface Identifiable {
-  guid: string;
+  guid: Guid;
 }
 
 // deno-lint-ignore no-explicit-any ban-types
@@ -9,13 +17,13 @@ type Constructor<T = {}> = new (...args: any[]) => T;
 /** Mixin providing an `Identifiable` implementation based on UUID4 */
 export function IdentifiableMixin<TBase extends Constructor>(Base: TBase) {
   return class extends Base implements Identifiable {
-    readonly guid: string;
+    readonly guid: Guid;
 
     // deno-lint-ignore no-explicit-any
     constructor(...args: any[]) {
       super(...args);
 
-      this.guid = crypto.randomUUID();
+      this.guid = guid.new();
     }
   };
 }

--- a/core/mod.ts
+++ b/core/mod.ts
@@ -1,2 +1,3 @@
 export * from "./errors.ts";
 export * from "./identifiable.ts";
+export * from "./component.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,17 +1,19 @@
 export { multiaddr } from "https://cdn.skypack.dev/@multiformats/multiaddr@11.4.0?dts";
 export type { Multiaddr } from "https://cdn.skypack.dev/@multiformats/multiaddr@11.4.0?dts";
-
 export { multiaddrToUri } from "https://cdn.skypack.dev/@multiformats/multiaddr-to-uri@9.0.2?dts";
 
+export { z } from "https://deno.land/x/zod@v3.20.5/mod.ts";
+
+// Deno std libs
+// If adding Deno std libs ensure only modules that are browser compatible are used!
+// Browser compatible modules have a "This module is browser compatible." string in the root `mod.ts`
+export * as log from "https://deno.land/std@0.176.0/log/mod.ts";
+export * as semver from "https://deno.land/std@0.176.0/semver/mod.ts";
+export * as datetime from "https://deno.land/std@0.176.0/datetime/mod.ts";
 export {
   decode as base64Decode,
   encode as base64Encode,
 } from "https://deno.land/std@0.176.0/encoding/base64.ts";
-
-export { z } from "https://deno.land/x/zod@v3.20.5/mod.ts";
-
-export * as log from "https://deno.land/std@0.176.0/log/mod.ts";
-export * as semver from "https://deno.land/std@0.176.0/semver/mod.ts";
 
 export {
   default as lodashMerge,
@@ -20,7 +22,6 @@ export {
 // structuredClone isn't available in some web envs (like Tizen) yet.
 export { default as structuredClone } from "https://cdn.skypack.dev/@ungap/structured-clone@1.0.2";
 
-export { default as blakejs } from "https://cdn.skypack.dev/blakejs@1.2.1";
-
 // crypto dependencies
 export * as secp256k1 from "https://esm.sh/@noble/secp256k1@2.0.0"; // there was a issue using skypack
+export { default as blakejs } from "https://cdn.skypack.dev/blakejs@1.2.1";

--- a/node/node.ts
+++ b/node/node.ts
@@ -108,7 +108,7 @@ export class Ogre extends Component<NodeEvents> {
           "peer:message:recv",
           ({ detail: msg }) => msgHandler.handle(msg, peer),
         );
-        this.#forwardEvent(e);
+        this.#bubbleEvent(e);
       },
     );
 
@@ -117,7 +117,7 @@ export class Ogre extends Component<NodeEvents> {
       const { peer } = e.detail;
 
       syncManager.discardPeer(peer);
-      this.#forwardEvent(e);
+      this.#bubbleEvent(e);
     });
   }
 
@@ -153,7 +153,7 @@ export class Ogre extends Component<NodeEvents> {
     return version;
   }
 
-  #forwardEvent<T>(e: CustomEvent<T>) {
+  #bubbleEvent<T>(e: CustomEvent<T>) {
     this.dispatchEvent(new CustomEvent(e.type, { detail: e.detail }));
   }
 }

--- a/node/node.ts
+++ b/node/node.ts
@@ -9,6 +9,7 @@ import { log } from "../deps.ts";
 import { setupLogging } from "../log/mod.ts";
 import { ConnectionManager } from "../net/mod.ts";
 import { PeerManager, PeerManagerEvents, PeerStore } from "../peers/mod.ts";
+import { SyncManager } from "../peers/sync.ts";
 import {
   DefaultMessageHandler,
   DefaultNetworkMessageCodec,
@@ -76,6 +77,12 @@ export class Ogre extends Component<NodeEvents> {
       logger: this.#logger,
     });
 
+    const syncManager = new SyncManager({
+      logger: this.#logger,
+      config: this.config,
+    });
+    this.#components.push(syncManager);
+
     this.#peerManager = new PeerManager({
       logger: this.#logger,
       config: this.config,
@@ -83,33 +90,35 @@ export class Ogre extends Component<NodeEvents> {
     });
     this.#components.push(this.#peerManager);
 
-    // metric gatherer? subscribe to events from previous components
-
+    // handle new connections
     connectionManager.addEventListener(
       "connection:new",
       ({ detail }) => this.#peerManager.acceptConnection(detail),
     );
+
     // handle new peers
     this.#peerManager.addEventListener(
       "peer:new",
-      ({ detail: peer }) => {
+      (e) => {
+        const { detail: peer } = e;
+
+        syncManager.monitorPeer(peer);
         // handle peer messages received
         peer.addEventListener(
           "peer:message:recv",
           ({ detail: msg }) => msgHandler.handle(msg, peer),
         );
+        this.#forwardEvent(e);
       },
     );
 
-    // forward events and emit from node
-    this.#peerManager.addEventListener(
-      "peer:new",
-      (e) => this.#forwardEvent(e),
-    );
-    this.#peerManager.addEventListener(
-      "peer:removed",
-      (e) => this.#forwardEvent(e),
-    );
+    // Handle peer removed events
+    this.#peerManager.addEventListener("peer:removed", (e) => {
+      const { peer } = e.detail;
+
+      syncManager.discardPeer(peer);
+      this.#forwardEvent(e);
+    });
   }
 
   async start(): Promise<void> {

--- a/peers/peer_manager.ts
+++ b/peers/peer_manager.ts
@@ -57,12 +57,7 @@ export class PeerManager extends Component<PeerManagerEvents> {
     this.#codec = codec;
   }
 
-  /** Currently connected and active peers */
-  get peers(): Peer[] {
-    return this.#peers;
-  }
-
-  start(): Promise<void> {
+  override start(): Promise<void> {
     const { gossipIntervalSec, evictIntervalSec } = this.#config.peers;
 
     this.#getPeersTaskHandle = setInterval(
@@ -77,7 +72,7 @@ export class PeerManager extends Component<PeerManagerEvents> {
     return Promise.resolve();
   }
 
-  async stop(): Promise<void> {
+  override async stop(): Promise<void> {
     clearInterval(this.#getPeersTaskHandle);
     clearInterval(this.#evictPeersTaskHandle);
 

--- a/peers/peer_manager.ts
+++ b/peers/peer_manager.ts
@@ -84,6 +84,13 @@ export class PeerManager extends Component<PeerManagerEvents> {
     await Promise.all(this.#peers.map((peer) => peer.stop()));
   }
 
+  removePeer(peer: Peer) {
+    // remove from this.#peers
+    // emit peer:removed event
+    // components that care about peers being removed should listen for this event
+    // and not peer:stopped
+  }
+
   /**
    * Select a random peer from our currently connected peers to send
    * a `GetPeersMessage` message to. This enables us to gossip and

--- a/peers/peer_manager.ts
+++ b/peers/peer_manager.ts
@@ -57,6 +57,11 @@ export class PeerManager extends Component<PeerManagerEvents> {
     this.#codec = codec;
   }
 
+  /** Currently connected and active peers */
+  get peers(): Peer[] {
+    return this.#peers;
+  }
+
   start(): Promise<void> {
     const { gossipIntervalSec, evictIntervalSec } = this.#config.peers;
 

--- a/peers/peers_query.ts
+++ b/peers/peers_query.ts
@@ -1,5 +1,6 @@
 import { semver } from "../deps.ts";
 import { NetworkMessage } from "../protocol/mod.ts";
+import { Version } from "../protocol/version.ts";
 import { Peer } from "./peer.ts";
 
 export function _peers(peers: Peer[]) {
@@ -25,16 +26,19 @@ export function peersQuery(peers: Peer[]) {
   return {
     /** Filter peers that cannot handle the provided `NetworkMessage`. */
     canHandle(msg: NetworkMessage) {
-      const requiredVer = msg.protocolVersion.toString();
-
+      return this.cmpVersion(">=", msg.protocolVersion);
+    },
+    /** Filter peers by their declared version based on the operator */
+    cmpVersion(op: semver.Operator, ver: Version | string) {
       filteredPeers = filteredPeers.filter((p) => {
         if (!p.handshake) {
           return false;
         }
 
         const peerVer = p.handshake.peerSpec.refNodeVersion.toString();
+        const verStr = ver instanceof Version ? ver.toString() : ver;
 
-        return semver.gte(peerVer, requiredVer);
+        return semver.cmp(peerVer, op, verStr);
       });
 
       return this;

--- a/peers/sync.ts
+++ b/peers/sync.ts
@@ -47,7 +47,15 @@ function getStatesByChainSyncState(
   return states.filter((s) => s.chainState === chainState);
 }
 
-export const _internals = { getStatesByOutdated, getStatesByChainSyncState };
+function states(states: PeerSyncState[]): PeerSyncState[] {
+  return states;
+}
+
+export const _internals = {
+  states,
+  getStatesByOutdated,
+  getStatesByChainSyncState,
+};
 
 export class SyncManager extends Component {
   /** Seconds that must have elapsed before we consider peer for another `SyncInfo` message */
@@ -117,10 +125,10 @@ export class SyncManager extends Component {
     // TODO: determine what to send in sync info msg
     const msg = new SyncInfoMessage(new SyncInfoV2([]));
 
-    states.forEach((s) => this.#sendSyncInfoByState(s, msg));
+    states.forEach((s) => this.#sendSyncInfoToState(s, msg));
   }
 
-  #sendSyncInfoByState(state: PeerSyncState, msg: SyncInfoMessage) {
+  #sendSyncInfoToState(state: PeerSyncState, msg: SyncInfoMessage) {
     if (
       !state.peer.handshake?.peerSpec.refNodeVersion.gte(
         REF_CLIENT_MILESTONE.syncV2,
@@ -173,10 +181,13 @@ export class SyncManager extends Component {
   }
 
   #outdatedStates(): PeerSyncState[] {
-    return _internals.getStatesByOutdated(this.#states);
+    return _internals.getStatesByOutdated(_internals.states(this.#states));
   }
 
   #statesByChainState(chainState: PeerChainState): PeerSyncState[] {
-    return _internals.getStatesByChainSyncState(this.#states, chainState);
+    return _internals.getStatesByChainSyncState(
+      _internals.states(this.#states),
+      chainState,
+    );
   }
 }

--- a/peers/sync.ts
+++ b/peers/sync.ts
@@ -1,0 +1,78 @@
+import { OgreConfig } from "../config/mod.ts";
+import { Component, Guid } from "../core/mod.ts";
+import { log } from "../deps.ts";
+import { SyncInfoMessage } from "../protocol/messages/sync_info/mod.ts";
+import { REF_CLIENT_MILESTONE, SyncInfoV2 } from "../protocol/mod.ts";
+import { PeerManager } from "./peer_manager.ts";
+import { peersQuery } from "./peers_query.ts";
+
+export interface SyncManagerOpts {
+  logger: log.Logger;
+  config: OgreConfig;
+  peerManager: PeerManager;
+}
+
+/** State of the peers chain in relation to our own */
+export enum PeerChainState {
+  Equal,
+  Unknown,
+  Younger,
+  Fork,
+  Older,
+}
+
+export interface PeerSyncStatus {
+  state: PeerChainState;
+  height: number;
+}
+
+export class SyncManager extends Component {
+  readonly #logger: log.Logger;
+  readonly #config: OgreConfig;
+  readonly #peerManager: PeerManager;
+  #sendSyncInfoTaskHandle?: number;
+  /** Peer guid to sync state mapping */
+  readonly #peerSyncMap: Record<Guid, PeerSyncStatus> = {};
+
+  constructor({ config, logger, peerManager }: SyncManagerOpts) {
+    super();
+
+    this.#config = config;
+    this.#logger = logger;
+    this.#peerManager = peerManager;
+  }
+
+  start(): Promise<void> {
+    this.#sendSyncInfoTaskHandle = setInterval(
+      () => this.sendSyncInfo(),
+      this.#config.peers.syncIntervalSec * 1000,
+    );
+
+    return Promise.resolve();
+  }
+
+  stop(): Promise<void> {
+    clearInterval(this.#sendSyncInfoTaskHandle);
+
+    return Promise.resolve();
+  }
+
+  sendSyncInfo() {
+    // currently only v2 sync is supported
+    const peers = peersQuery(this.#peerManager.peers).cmpVersion(
+      ">=",
+      REF_CLIENT_MILESTONE.syncV2,
+    ).peers();
+
+    if (!peers.length) {
+      return;
+    }
+
+    this.#logger.info(`sendSyncInfo sending sync msg to ${peers.length} peers`);
+
+    // TODO: determine what to send in sync info msg
+    const msg = new SyncInfoMessage(new SyncInfoV2([]));
+    // update each peers last sync send time
+    peers.forEach((p) => p.send(msg));
+  }
+}

--- a/peers/sync.ts
+++ b/peers/sync.ts
@@ -81,6 +81,10 @@ export class SyncManager extends Component {
     return Promise.resolve();
   }
 
+  get states(): readonly PeerSyncState[] {
+    return this.#states;
+  }
+
   getPeerSyncState(peer: Peer): PeerSyncState | undefined {
     return this.#states.find((ps) => ps.peer.isEqual(peer));
   }

--- a/peers/sync.ts
+++ b/peers/sync.ts
@@ -117,22 +117,24 @@ export class SyncManager extends Component {
     // TODO: determine what to send in sync info msg
     const msg = new SyncInfoMessage(new SyncInfoV2([]));
 
-    states.forEach((s) => {
-      if (
-        !s.peer.handshake?.peerSpec.refNodeVersion.gte(
-          REF_CLIENT_MILESTONE.syncV2,
-        )
-      ) {
-        this.#logger.info(
-          "sendSyncInfo skipping node with SyncInfoV1 or no handshake",
-        );
+    states.forEach((s) => this.#sendSyncInfoByState(s, msg));
+  }
 
-        return;
-      }
+  #sendSyncInfoByState(state: PeerSyncState, msg: SyncInfoMessage) {
+    if (
+      !state.peer.handshake?.peerSpec.refNodeVersion.gte(
+        REF_CLIENT_MILESTONE.syncV2,
+      )
+    ) {
+      this.#logger.info(
+        "sendSyncInfo skipping node with SyncInfoV1 or no handshake",
+      );
 
-      s.lastSyncSentAt = new Date();
-      s.peer.send(msg);
-    });
+      return;
+    }
+
+    state.lastSyncSentAt = new Date();
+    state.peer.send(msg);
   }
 
   #getStatesForSyncInfoMsg(): PeerSyncState[] {

--- a/peers/sync_test.ts
+++ b/peers/sync_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "../test_deps.ts";
+import { assertEquals, assertSpyCalls, FakeTime, spy } from "../test_deps.ts";
 import { createRandomPeer, createRandomSyncManager } from "./testing.ts";
 
 Deno.test("[peers/sync] SyncManager.monitorPeer doesn't add duplicate peers to state", () => {
@@ -45,4 +45,39 @@ Deno.test("[peers/sync] SyncManager.getPeerSyncState returns the state for the s
   assertEquals(sm.getPeerSyncState(peer2)?.peer, peer2);
   assertEquals(sm.getPeerSyncState(peer)?.peer, peer);
   assertEquals(sm.getPeerSyncState(peer3)?.peer, peer3);
+});
+
+Deno.test("[peers/sync] SyncManager.getPeerSyncState returns the state for the supplied peer", () => {
+  const sm = createRandomSyncManager();
+  const peer = createRandomPeer();
+  const peer2 = createRandomPeer();
+  const peer3 = createRandomPeer();
+
+  sm.monitorPeer(peer2);
+  sm.monitorPeer(peer);
+  sm.monitorPeer(peer3);
+
+  assertEquals(sm.getPeerSyncState(peer2)?.peer, peer2);
+  assertEquals(sm.getPeerSyncState(peer)?.peer, peer);
+  assertEquals(sm.getPeerSyncState(peer3)?.peer, peer3);
+});
+
+Deno.test("[peers/sync] SyncManager.sendSyncInfo is called at supplied interval", async () => {
+  const time = new FakeTime();
+  const sm = createRandomSyncManager(60);
+  const sendSyncSpy = spy(sm, "sendSyncInfo");
+
+  await sm.start();
+
+  try {
+    assertSpyCalls(sendSyncSpy, 0);
+    time.tick(30 * 1000);
+    assertSpyCalls(sendSyncSpy, 0);
+    time.tick(40 * 1000); // 70 seconds
+    assertSpyCalls(sendSyncSpy, 1);
+    time.tick(55 * 1000);
+    assertSpyCalls(sendSyncSpy, 2);
+  } finally {
+    time.restore();
+  }
 });

--- a/peers/sync_test.ts
+++ b/peers/sync_test.ts
@@ -81,3 +81,11 @@ Deno.test("[peers/sync] SyncManager.sendSyncInfo is called at supplied interval"
     time.restore();
   }
 });
+
+Deno.test("[peers/sync] SyncManager.sendSyncInfo prefers outdated sync states", () => {
+  const sm = createRandomSyncManager();
+  // create random sync states
+  // some with "outdated" states
+  // call sm.sendSyncInfo
+  // ensure only outdated state.peer send was called
+});

--- a/peers/sync_test.ts
+++ b/peers/sync_test.ts
@@ -1,0 +1,48 @@
+import { assertEquals } from "../test_deps.ts";
+import { createRandomPeer, createRandomSyncManager } from "./testing.ts";
+
+Deno.test("[peers/sync] SyncManager.monitorPeer doesn't add duplicate peers to state", () => {
+  const sm = createRandomSyncManager();
+  const peer = createRandomPeer();
+
+  sm.monitorPeer(peer);
+
+  assertEquals(sm.states.length, 1);
+  sm.monitorPeer(peer);
+  assertEquals(sm.states.length, 1);
+});
+
+Deno.test("[peers/sync] SyncManager.discardPeer removes supplied peer from states", () => {
+  const sm = createRandomSyncManager();
+  const peer = createRandomPeer();
+  const peer2 = createRandomPeer();
+  const peer3 = createRandomPeer();
+
+  sm.monitorPeer(peer);
+  sm.monitorPeer(peer2);
+  sm.monitorPeer(peer3);
+
+  assertEquals(sm.states.length, 3);
+
+  sm.discardPeer(peer2);
+
+  assertEquals(sm.states.length, 2);
+
+  const discardedPeer = sm.states.find((p) => p.peer.isEqual(peer2));
+  assertEquals(discardedPeer, undefined);
+});
+
+Deno.test("[peers/sync] SyncManager.getPeerSyncState returns the state for the supplied peer", () => {
+  const sm = createRandomSyncManager();
+  const peer = createRandomPeer();
+  const peer2 = createRandomPeer();
+  const peer3 = createRandomPeer();
+
+  sm.monitorPeer(peer2);
+  sm.monitorPeer(peer);
+  sm.monitorPeer(peer3);
+
+  assertEquals(sm.getPeerSyncState(peer2)?.peer, peer2);
+  assertEquals(sm.getPeerSyncState(peer)?.peer, peer);
+  assertEquals(sm.getPeerSyncState(peer3)?.peer, peer3);
+});

--- a/peers/testing.ts
+++ b/peers/testing.ts
@@ -9,7 +9,7 @@ import { createRandomHandlerContext } from "../protocol/messages/testing.ts";
 import { PeerManager } from "./peer_manager.ts";
 import { createRandomConfig } from "../config/testing.ts";
 import { Connection } from "../net/mod.ts";
-import { SyncManager } from "./sync.ts";
+import { PeerChainState, PeerSyncState, SyncManager } from "./sync.ts";
 
 export function createRandomPeerStore(): PeerStore {
   return new PeerStore({ logger: log.getLogger(), configAddrs: [] });
@@ -67,4 +67,18 @@ export function createRandomSyncManager(syncIntervalSec?: number) {
   }
 
   return new SyncManager({ config, logger: log.getLogger() });
+}
+
+export function createRandomPeerSyncState(
+  opts: Partial<PeerSyncState>,
+): PeerSyncState {
+  const defaults: PeerSyncState = {
+    peer: createRandomPeer(),
+    chainState: PeerChainState.Unknown,
+  };
+
+  return {
+    ...defaults,
+    ...opts,
+  };
 }

--- a/peers/testing.ts
+++ b/peers/testing.ts
@@ -9,6 +9,7 @@ import { createRandomHandlerContext } from "../protocol/messages/testing.ts";
 import { PeerManager } from "./peer_manager.ts";
 import { createRandomConfig } from "../config/testing.ts";
 import { Connection } from "../net/mod.ts";
+import { SyncManager } from "./sync.ts";
 
 export function createRandomPeerStore(): PeerStore {
   return new PeerStore({ logger: log.getLogger(), configAddrs: [] });
@@ -56,4 +57,14 @@ export function createRandomPeerManager(
     codec: ctx.codec,
     config,
   });
+}
+
+export function createRandomSyncManager(sendSyncInterval?: number) {
+  const config = createRandomConfig();
+
+  if (sendSyncInterval) {
+    config.peers.syncIntervalSec = sendSyncInterval;
+  }
+
+  return new SyncManager({ config, logger: log.getLogger() });
 }

--- a/peers/testing.ts
+++ b/peers/testing.ts
@@ -59,11 +59,11 @@ export function createRandomPeerManager(
   });
 }
 
-export function createRandomSyncManager(sendSyncInterval?: number) {
+export function createRandomSyncManager(syncIntervalSec?: number) {
   const config = createRandomConfig();
 
-  if (sendSyncInterval) {
-    config.peers.syncIntervalSec = sendSyncInterval;
+  if (syncIntervalSec) {
+    config.peers.syncIntervalSec = syncIntervalSec;
   }
 
   return new SyncManager({ config, logger: log.getLogger() });

--- a/protocol/message.ts
+++ b/protocol/message.ts
@@ -1,9 +1,10 @@
 import { CursorReader, CursorWriter } from "../io/cursor_buffer.ts";
 import { NetworkEncodable } from "./encoding.ts";
 import { BadLengthError, InvalidChecksumError } from "./errors.ts";
-import { initialNodeVersion, Version } from "./version.ts";
+import { Version } from "./version.ts";
 import { blakejs } from "../deps.ts";
 import { isBytesEq } from "../_utils/mod.ts";
+import { REF_CLIENT_MILESTONE } from "./ref_client.ts";
 
 /** Identifiers for messages that make up the protocol */
 export enum MessageCode {
@@ -37,7 +38,7 @@ export abstract class NetworkMessage
 /** Network messages that have existed since the initial launch of the network */
 export abstract class InitialNetworkMessage extends NetworkMessage {
   get protocolVersion(): Version {
-    return initialNodeVersion;
+    return REF_CLIENT_MILESTONE.initial;
   }
 }
 

--- a/protocol/mod.ts
+++ b/protocol/mod.ts
@@ -2,4 +2,6 @@ export * from "./messages/handshake/mod.ts";
 export * from "./peer_spec/mod.ts";
 export * from "./messages/mod.ts";
 export * from "./codec.ts";
+export * from "./ref_client.ts";
+export * from "./sync_info.ts";
 export { NetworkMessage } from "./message.ts";

--- a/protocol/ref_client.ts
+++ b/protocol/ref_client.ts
@@ -4,7 +4,7 @@ import { Version } from "./version.ts";
 export const REF_CLIENT_MILESTONE = {
   /** Initial launch version */
   initial: new Version(0, 0, 1),
-  /** Sync v2 introduced */
+  /** Sync v2 introduced, determines if the client supports SyncInfoV2 based `SyncInfo` messages */
   syncV2: new Version(4, 0, 16),
   /** Delivering broken block sections */
   brokenBlockSection4017: new Version(4, 0, 17),

--- a/protocol/ref_client.ts
+++ b/protocol/ref_client.ts
@@ -1,0 +1,13 @@
+import { Version } from "./version.ts";
+
+/** Version milestones for the ergo reference client */
+export const REF_CLIENT_MILESTONE = {
+  /** Initial launch version */
+  initial: new Version(0, 0, 1),
+  /** Sync v2 introduced */
+  syncV2: new Version(4, 0, 16),
+  /** Delivering broken block sections */
+  brokenBlockSection4017: new Version(4, 0, 17),
+  /** Delivering broken block sections */
+  brokenBlockSection4018: new Version(4, 0, 18),
+};

--- a/protocol/version.ts
+++ b/protocol/version.ts
@@ -45,9 +45,3 @@ export class Version implements NetworkEncodable {
     return new Version(major, minor, patch);
   }
 }
-
-/** Reference node client versions */
-export const initialNodeVersion = new Version(0, 0, 1);
-/** Reference client nodes of the following versions deliver broken block sections */
-export const v4017 = new Version(4, 0, 17);
-export const v4018 = new Version(4, 0, 18);

--- a/protocol/version.ts
+++ b/protocol/version.ts
@@ -1,6 +1,11 @@
 import { CursorReader, CursorWriter } from "../io/cursor_buffer.ts";
 import { isSemVer } from "../_utils/isSemVer.ts";
+import { semver } from "../deps.ts";
 import { NetworkEncodable } from "./encoding.ts";
+
+function ensureString(ver: Version | string): string {
+  return ver instanceof Version ? ver.toString() : ver;
+}
 
 /** Represents a version of an entity on the network. */
 export class Version implements NetworkEncodable {
@@ -18,6 +23,10 @@ export class Version implements NetworkEncodable {
     writer.putInt8(this.major);
     writer.putInt8(this.minor);
     writer.putInt8(this.patch);
+  }
+
+  gte(other: Version | string): boolean {
+    return semver.gte(this.toString(), ensureString(other));
   }
 
   static decode(reader: CursorReader): Version {

--- a/protocol/version_test.ts
+++ b/protocol/version_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "../test_deps.ts";
+import { assert, assertEquals } from "../test_deps.ts";
 import { ScorexReader, ScorexWriter } from "../io/scorex_buffer.ts";
 import { Version } from "./version.ts";
 
@@ -26,4 +26,10 @@ Deno.test("[protocol/version] ToString conversion", () => {
   const ver = new Version(4, 3, 9);
 
   assertEquals(ver.toString(), "4.3.9");
+});
+
+Deno.test("[protocol/version] gte", () => {
+  const ver = new Version(4, 3, 9);
+
+  assert(ver.gte("4.3.8"));
 });


### PR DESCRIPTION
closes #89 

- [ ] Add `SyncManager` unit tests
  - [x] Duplicate states aren't added in `monitorPeer`
  - [x] `discardPeer` removes `peer` from tracked states
  - [x] `getPeerState` returns the state corresponding to the peer
  - [x] Test `sendSyncInfo` is called at interval supplied in config
  - [ ] `sendSyncInfo` main function requiring testing
    - [ ] Prefers `outdated` sync states
    - [ ] Always sends to states with `unknown` or `fork` state
    - [ ] Sends to a random `elder` if elders exist
    - [ ] Excludes states that we sent a `SyncInfo` message to less than `MIN_SYNC_INTERVAL_SEC` ago
    - [ ] Updates `lastSyncSentAt` timestamp for states that receive a msg
    - [ ] Excludes nodes that don't support `SyncInfoV2` (for now) 