### PR TITLE
Make connection objects emit close events

### DIFF
--- a/net/connection.ts
+++ b/net/connection.ts
@@ -1,10 +1,15 @@
 import { Multiaddr } from "../deps.ts";
+import { EventEmitter } from "../events/mod.ts";
 
 /** The direction of the connection. */
 export type ConnectionDirection = "inbound" | "outbound";
 
+export interface ConnectionEvents {
+  "connection:close": CustomEvent;
+}
+
 /** A connection to a remote peer. */
-export interface Connection {
+interface BaseConnection {
   /** Unique id assigned to the connection, uuid4 format. */
   connId: string;
   /** Local address for the connection. */
@@ -19,4 +24,20 @@ export interface Connection {
   readable: ReadableStream<Uint8Array>;
   /** Close the connection. */
   close: () => void;
+}
+
+export type Connection = BaseConnection & EventEmitter<ConnectionEvents>;
+
+/** Wrap the connection so it emits events */
+export function createConnection(base: BaseConnection): Connection {
+  // const conn = new EventEmitter<ConnectionEvents>() as Connection;
+
+  const conn = Object.assign(new EventEmitter<ConnectionEvents>(), base);
+
+  conn.close = () => {
+    base.close();
+    conn.dispatchEvent(new CustomEvent("connection:close"));
+  };
+
+  return conn;
 }

--- a/net/connection.ts
+++ b/net/connection.ts
@@ -30,8 +30,6 @@ export type Connection = BaseConnection & EventEmitter<ConnectionEvents>;
 
 /** Wrap the connection so it emits events */
 export function createConnection(base: BaseConnection): Connection {
-  // const conn = new EventEmitter<ConnectionEvents>() as Connection;
-
   const conn = Object.assign(new EventEmitter<ConnectionEvents>(), base);
 
   conn.close = () => {

--- a/net/connection_manager.ts
+++ b/net/connection_manager.ts
@@ -67,6 +67,11 @@ export class ConnectionManager extends Component<ConnectionManagerEvents> {
     // add to "pending connections" list, so it can be cancelled?
     const conn = await this.#transport.dial(addr, opts);
 
+    conn.addEventListener(
+      "connection:close",
+      (e) => this.onConnectionClose((e.target as Connection).connId),
+    );
+
     this.#connections.push(conn);
     this.dispatchEvent(new CustomEvent("connection:new", { detail: conn }));
 

--- a/net/connection_manager.ts
+++ b/net/connection_manager.ts
@@ -121,6 +121,11 @@ export class ConnectionManager extends Component<ConnectionManagerEvents> {
     );
   }
 
+  /** The amount of active connections */
+  get connectionCount(): number {
+    return this.#connections.length;
+  }
+
   private async autoDialPeer(): Promise<void> {
     if (this.#connections.length >= this.#maxConnections) {
       this.#logger.debug("already at max connections");

--- a/net/connection_manager.ts
+++ b/net/connection_manager.ts
@@ -104,7 +104,21 @@ export class ConnectionManager extends Component<ConnectionManagerEvents> {
   }
 
   onConnectionClose(connId: string) {
+    const conn = this.#connections.find((c) => c.connId === connId);
+
+    if (!conn) {
+      this.#logger.debug(
+        `onConnectionClose: connection id not found '${connId}'`,
+      );
+
+      return;
+    }
+
     this.#connections = this.#connections.filter((c) => c.connId !== connId);
+
+    this.#logger.info(
+      `closed connection to ${conn.remoteAddr.toString()}, connections ${this.#connections.length}/${this.#maxConnections}`,
+    );
   }
 
   private async autoDialPeer(): Promise<void> {

--- a/net/connection_manager.ts
+++ b/net/connection_manager.ts
@@ -117,7 +117,7 @@ export class ConnectionManager extends Component<ConnectionManagerEvents> {
     this.#connections = this.#connections.filter((c) => c.connId !== connId);
 
     this.#logger.info(
-      `closed connection to ${conn.remoteAddr.toString()}, connections ${this.#connections.length}/${this.#maxConnections}`,
+      `removed connection to ${conn.remoteAddr.toString()}, connections ${this.#connections.length}/${this.#maxConnections}`,
     );
   }
 

--- a/net/connection_manager_test.ts
+++ b/net/connection_manager_test.ts
@@ -1,0 +1,18 @@
+import { toMultiaddr } from "../multiaddr/mod.ts";
+import { assertEquals, assertSpyCalls, faker, spy } from "../test_deps.ts";
+import { createRandomConnectionManager } from "./testing.ts";
+
+Deno.test("[net/connection_manager] Connections are removed when Connection.close is called", async () => {
+  const addr = toMultiaddr(`${faker.internet.ipv4()}:${faker.internet.port()}`);
+  const cm = createRandomConnectionManager();
+  const closeSpy = spy(cm, "onConnectionClose");
+
+  const conn = await cm.openConnection(addr);
+
+  assertEquals(cm.connectionCount, 1);
+
+  conn.close();
+
+  assertSpyCalls(closeSpy, 1);
+  assertEquals(cm.connectionCount, 0);
+});

--- a/net/connection_test.ts
+++ b/net/connection_test.ts
@@ -1,0 +1,25 @@
+import { toMultiaddr } from "../multiaddr/mod.ts";
+import { assertSpyCalls, faker, spy } from "../test_deps.ts";
+import { createConnection } from "./connection.ts";
+
+Deno.test("[net/connection] Connections wrapped by createConnection emit `connection:close` events", () => {
+  const localAddr = `127.0.0.1:${faker.internet.port()}`;
+  const remoteAddr = `${faker.internet.ipv4()}:${faker.internet.port()}`;
+
+  const conn = createConnection({
+    connId: "1",
+    localAddr: toMultiaddr(localAddr),
+    remoteAddr: toMultiaddr(remoteAddr),
+    direction: "inbound",
+    readable: new ReadableStream({}),
+    writable: new WritableStream({}),
+    close: () => undefined,
+  });
+  const onClose = () => undefined;
+  const onCloseSpy = spy(onClose);
+
+  conn.addEventListener("connection:close", onCloseSpy);
+  conn.close();
+
+  assertSpyCalls(onCloseSpy, 1);
+});

--- a/net/testing.ts
+++ b/net/testing.ts
@@ -1,6 +1,10 @@
 import { Connection, createConnection } from "./connection.ts";
 import { faker } from "../test_deps.ts";
 import { toMultiaddr } from "../multiaddr/mod.ts";
+import { ConnectionManager } from "./connection_manager.ts";
+import { log } from "../deps.ts";
+import { createRandomPeerStore } from "../peers/testing.ts";
+import { createRandomTransport } from "../transports/testing.ts";
 
 export function createRandomConnection(): Connection {
   const localAddr = `127.0.0.1:${faker.internet.port()}`;
@@ -16,5 +20,14 @@ export function createRandomConnection(): Connection {
     readable,
     writable,
     close: () => undefined,
+  });
+}
+
+export function createRandomConnectionManager(): ConnectionManager {
+  return new ConnectionManager({
+    logger: log.getLogger(),
+    maxConnections: 5,
+    peerStore: createRandomPeerStore(),
+    transport: createRandomTransport(),
   });
 }

--- a/net/testing.ts
+++ b/net/testing.ts
@@ -1,4 +1,4 @@
-import { Connection } from "./connection.ts";
+import { Connection, createConnection } from "./connection.ts";
 import { faker } from "../test_deps.ts";
 import { toMultiaddr } from "../multiaddr/mod.ts";
 
@@ -8,7 +8,7 @@ export function createRandomConnection(): Connection {
   const readable = new ReadableStream({});
   const writable = new WritableStream({});
 
-  return {
+  return createConnection({
     connId: faker.datatype.uuid(),
     localAddr: toMultiaddr(localAddr),
     remoteAddr: toMultiaddr(remoteAddr),
@@ -16,5 +16,5 @@ export function createRandomConnection(): Connection {
     readable,
     writable,
     close: () => undefined,
-  };
+  });
 }

--- a/node/node.ts
+++ b/node/node.ts
@@ -93,11 +93,6 @@ export class Ogre extends Component<NodeEvents> {
     this.#peerManager.addEventListener(
       "peer:new",
       ({ detail: peer }) => {
-        // remove peer connection from connection manager
-        peer.addEventListener(
-          "peer:stopped",
-          () => connectionManager.onConnectionClose(peer.connId),
-        );
         // handle peer messages received
         peer.addEventListener(
           "peer:message:recv",

--- a/transports/bridges/web_socket/mod.ts
+++ b/transports/bridges/web_socket/mod.ts
@@ -1,4 +1,4 @@
-import { Connection } from "../../../net/mod.ts";
+import { Connection, createConnection } from "../../../net/mod.ts";
 import { Multiaddr, multiaddrToUri } from "../../../deps.ts";
 import { toMultiaddr } from "../../../multiaddr/mod.ts";
 import { Listener } from "../../listener.ts";
@@ -51,7 +51,7 @@ export function websocketBridgeTransport(opts: WebSocketBridgeOpts): Transport {
         },
       );
 
-      return {
+      return createConnection({
         connId,
         localAddr: toMultiaddr(localAddr),
         remoteAddr: toMultiaddr(remoteAddr),
@@ -59,7 +59,7 @@ export function websocketBridgeTransport(opts: WebSocketBridgeOpts): Transport {
         readable,
         writable,
         close,
-      };
+      });
     },
     createListener(): Listener {
       throw new Error("Method not implemented.");

--- a/transports/tcp.ts
+++ b/transports/tcp.ts
@@ -1,6 +1,6 @@
 import { Multiaddr } from "../deps.ts";
 import { toMultiaddr } from "../multiaddr/mod.ts";
-import { Connection } from "../net/connection.ts";
+import { Connection, createConnection } from "../net/connection.ts";
 import { Listener } from "./listener.ts";
 import { DialOpts, Transport } from "./transport.ts";
 
@@ -27,7 +27,7 @@ export function tcpTransport(): Transport {
       const { port, host: hostname } = addr.toOptions();
       const conn = await Deno.connect({ port, hostname });
 
-      return {
+      return createConnection({
         connId,
         localAddr: denoAddrToMulti(conn.localAddr as Deno.NetAddr),
         remoteAddr: denoAddrToMulti(conn.remoteAddr as Deno.NetAddr),
@@ -35,7 +35,7 @@ export function tcpTransport(): Transport {
         readable: conn.readable,
         writable: conn.writable,
         close: () => conn.close(),
-      };
+      });
     },
     createListener(): Listener {
       throw new Error("not implemented yet");

--- a/transports/testing.ts
+++ b/transports/testing.ts
@@ -1,0 +1,15 @@
+import { Multiaddr } from "../deps.ts";
+import { createRandomConnection } from "../net/testing.ts";
+import { Listener } from "./listener.ts";
+import { Transport } from "./transport.ts";
+
+export function createRandomTransport(): Transport {
+  return {
+    dial(_addr: Multiaddr) {
+      return Promise.resolve(createRandomConnection());
+    },
+    createListener() {
+      return {} as Listener;
+    },
+  };
+}


### PR DESCRIPTION
- [x] test that connections wrapped by `createConnection` emit a `connection:close` event
- [x] test connection manager `onConnectionClose` is called when `connection.close` is called